### PR TITLE
refactor: stabilize cloud persistence foundation

### DIFF
--- a/docs/supabase-schema.sql
+++ b/docs/supabase-schema.sql
@@ -1,6 +1,12 @@
 -- QuantumX Supabase schema draft
 -- Run this in a new Supabase project before connecting the frontend.
--- The current app still runs in local-first mode; this schema prepares the cloud data model.
+-- The current app is local-first. When Supabase env vars are configured,
+-- this schema matches src/services/cloudMigration.ts and enables:
+-- 1. account-scoped cloud restore,
+-- 2. manual local-to-cloud migration,
+-- 3. cloud mode snapshot upserts after local writes.
+-- Do not rename distill_drafts, thought_topics, memory_feedback, or capture_drafts
+-- unless the repository / migration layer is updated in the same change.
 
 create extension if not exists pgcrypto;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,22 @@ function snapshotHasContent(snapshot: QuantumXDataSnapshot) {
   );
 }
 
+function isSeedOnlySnapshot(snapshot: QuantumXDataSnapshot) {
+  return (
+    snapshot.captureDraft.trim().length === 0 &&
+    snapshot.savedDistills.length === 0 &&
+    createSnapshotSignature({
+      thoughts: snapshot.thoughts,
+      topics: snapshot.topics,
+      savedDistills: [],
+      captureDraft: "",
+    }) === createSnapshotSignature(seedSnapshot)
+  );
+}
+
+function snapshotHasUserContent(snapshot: QuantumXDataSnapshot) {
+  return snapshotHasContent(snapshot) && !isSeedOnlySnapshot(snapshot);
+}
 const seedSnapshot: QuantumXDataSnapshot = {
   thoughts: seedThoughts,
   topics: seedTopics,
@@ -464,7 +480,7 @@ export default function App() {
             summary.topics > 0 ||
             summary.drafts > 0 ||
             summary.hasCaptureDraft;
-          const localHasData = snapshotHasContent(currentSnapshot);
+          const localHasData = snapshotHasUserContent(currentSnapshot);
 
           if (cloudHasData && !localHasData) {
             return supabaseQuantumXRepository.loadSnapshot(seedSnapshot).then((snapshot) => {

--- a/src/components/CloudModePanel.tsx
+++ b/src/components/CloudModePanel.tsx
@@ -508,8 +508,8 @@ export function CloudModePanel({
           邮箱登录
         </div>
         <p className="text-sm leading-7 text-muted">
-          入口其实在这里，只是当前这个站点还没有接好 Supabase，所以发送按钮暂时不可用。
-          等部署端补上环境变量后，这里就会直接变成可用的邮箱登录。
+入口就在这里。当前部署如果还没有配置 Supabase 环境变量，发送按钮会暂时不可用；
+配好后，邮箱登录会直接接入本地优先的云端同步链路。
         </p>
         <div className="mt-4 rounded-xl border border-line bg-canvas/70 p-4">
           {renderEmailLogin(
@@ -523,7 +523,7 @@ export function CloudModePanel({
           VITE_SUPABASE_ANON_KEY
         </div>
         <p className="mt-3 text-xs leading-6 text-muted">
-          等这两个环境变量在 Vercel 里配好后，邮箱登录就会立即可用。微信登录我们可以先不管。
+          等这两个环境变量在 Vercel 里配好后，邮箱登录和云端数据恢复就会立即可用。微信登录可以后续再接。
         </p>
       </section>
     );

--- a/src/pages/DataPage.tsx
+++ b/src/pages/DataPage.tsx
@@ -185,8 +185,8 @@ export function DataPage({
           数据与隐私
         </h1>
         <p className="mt-3 max-w-2xl text-sm leading-7 text-muted">
-          QuantumX 当前把记录保存在这个浏览器里。正式云同步上线前，你可以在这里备份、
-          迁移和恢复自己的思考数据。邮箱登录入口也在这一页右侧，不需要再去别的地方找。
+         QuantumX 默认先把记录保存在这个浏览器里。配置 Supabase 并登录后，你可以在这里备份、
+迁移、恢复数据，并切换到本地优先的云端同步模式。邮箱登录入口也在这一页右侧，不需要再去别的地方找。
         </p>
         <div className="mt-4 flex flex-wrap gap-2 text-xs">
           <span className="inline-flex items-center gap-1 rounded-full border border-line bg-white px-3 py-1.5 text-muted">
@@ -313,7 +313,7 @@ export function DataPage({
               当前保存方式
             </div>
             <p className="text-sm leading-7 text-muted">
-              数据只存在当前浏览器的 localStorage。换设备不会自动同步，清理浏览器数据会删除记录。
+              未登录或未切换到云端模式时，数据只存在当前浏览器的 localStorage。登录并同步后，QuantumX 会继续先写本地，再把整份 snapshot upsert 到 Supabase。
             </p>
           </div>
 

--- a/src/services/quantumxRepository.ts
+++ b/src/services/quantumxRepository.ts
@@ -6,15 +6,11 @@ import {
   migrateLocalSnapshotToSupabase,
   restoreSnapshotFromSupabase,
 } from "./cloudMigration";
-import type { QuantumXDataSnapshot, SavedDistill, Thought, Topic } from "../types";
+import type { QuantumXDataSnapshot } from "../types";
 
 export interface QuantumXRepository {
   loadSnapshot(fallback: QuantumXDataSnapshot): Promise<QuantumXDataSnapshot>;
   saveSnapshot(snapshot: QuantumXDataSnapshot): Promise<void>;
-  saveThoughts(thoughts: Thought[]): Promise<void>;
-  saveTopics(topics: Topic[]): Promise<void>;
-  saveDistills(savedDistills: SavedDistill[]): Promise<void>;
-  saveCaptureDraft(captureDraft: string): Promise<void>;
 }
 
 export function createLocalQuantumXRepository(scope: string): QuantumXRepository {
@@ -25,46 +21,6 @@ export function createLocalQuantumXRepository(scope: string): QuantumXRepository
 
     async saveSnapshot(snapshot) {
       writeScopedSnapshot(scope, snapshot);
-    },
-
-    async saveThoughts(thoughts) {
-      const current = readScopedSnapshot(scope, {
-        thoughts: [],
-        topics: [],
-        savedDistills: [],
-        captureDraft: "",
-      });
-      writeScopedSnapshot(scope, { ...current, thoughts });
-    },
-
-    async saveTopics(topics) {
-      const current = readScopedSnapshot(scope, {
-        thoughts: [],
-        topics: [],
-        savedDistills: [],
-        captureDraft: "",
-      });
-      writeScopedSnapshot(scope, { ...current, topics });
-    },
-
-    async saveDistills(savedDistills) {
-      const current = readScopedSnapshot(scope, {
-        thoughts: [],
-        topics: [],
-        savedDistills: [],
-        captureDraft: "",
-      });
-      writeScopedSnapshot(scope, { ...current, savedDistills });
-    },
-
-    async saveCaptureDraft(captureDraft) {
-      const current = readScopedSnapshot(scope, {
-        thoughts: [],
-        topics: [],
-        savedDistills: [],
-        captureDraft: "",
-      });
-      writeScopedSnapshot(scope, { ...current, captureDraft });
     },
   };
 }
@@ -82,22 +38,6 @@ export function createSupabaseQuantumXRepository(): QuantumXRepository {
 
     async saveSnapshot(snapshot) {
       await migrateLocalSnapshotToSupabase(snapshot);
-    },
-
-    async saveThoughts() {
-      throw new Error("Supabase repository requires saveSnapshot().");
-    },
-
-    async saveTopics() {
-      throw new Error("Supabase repository requires saveSnapshot().");
-    },
-
-    async saveDistills() {
-      throw new Error("Supabase repository requires saveSnapshot().");
-    },
-
-    async saveCaptureDraft() {
-      throw new Error("Supabase repository requires saveSnapshot().");
     },
   };
 }


### PR DESCRIPTION
## Summary

- Narrow QuantumX repository abstraction to snapshot-only persistence.
- Prevent demo seed data from being treated as real local user data during cloud bootstrap.
- Update cloud sync copy to reflect the current local-first + Supabase mode.
- Clarify Supabase schema comments so it stays aligned with `cloudMigration.ts`.

## Verification

- `npm run build`
- `npm run lint`