### PR TITLE
feat: add server-side AI distillation

### DIFF
--- a/src/pages/DistillPage.tsx
+++ b/src/pages/DistillPage.tsx
@@ -4,12 +4,15 @@ import {
   CheckCircle2,
   Copy,
   FilePenLine,
+  LoaderCircle,
   Save,
+  Sparkles,
   Trash2,
 } from "lucide-react";
 import { TopicBadge } from "../components/TopicBadge";
 import { SourceComposition } from "../components/SourceComposition";
 import { formatMonthDay } from "../lib/date";
+import { generateCloudDistill } from "../services/distillRepository";
 import type {
   DistillOutputType,
   SavedDistill,
@@ -95,6 +98,8 @@ export function DistillPage({
   const [selectedTopicId, setSelectedTopicId] = useState(topics[0]?.id ?? "");
   const [outputType, setOutputType] = useState<DistillOutputType>("文章提纲");
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generationMessage, setGenerationMessage] = useState("");
   const selectedTopic =
     topics.find((topic) => topic.id === selectedTopicId) ?? topics[0];
   if (!selectedTopic) {
@@ -149,6 +154,42 @@ export function DistillPage({
     );
   }
 
+  async function generateDistill() {
+    if (selectedThoughts.length === 0) return;
+
+    setIsGenerating(true);
+    setGenerationMessage("");
+    setActiveDraftId(null);
+
+    const fallbackContent = buildDistillContent(
+      selectedTopic,
+      selectedThoughts,
+      outputType,
+    );
+
+    try {
+      const result = await generateCloudDistill({
+        outputType,
+        topic: selectedTopic,
+        thoughts: selectedThoughts,
+      });
+
+      if (result) {
+        setEditableContent(result.content);
+        setGenerationMessage("已使用云端 AI 生成，可继续编辑后保存。");
+        return;
+      }
+
+      setEditableContent(fallbackContent);
+      setGenerationMessage("当前未登录或未配置云端 AI，已使用本地模板生成。");
+    } catch {
+      setEditableContent(fallbackContent);
+      setGenerationMessage("云端 AI 暂时不可用，已使用本地模板生成。");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
   function saveDraft() {
     if (selectedThoughts.length === 0) return;
 
@@ -185,6 +226,7 @@ export function DistillPage({
     setOutputType(draft.outputType);
     setSelectedThoughtIds(draft.sourceThoughtIds);
     setEditableContent(draft.content);
+    setGenerationMessage("");
   }
 
   async function copyMarkdown() {
@@ -219,6 +261,7 @@ export function DistillPage({
                 onClick={() => {
                   setActiveDraftId(null);
                   setSelectedTopicId(topic.id);
+                  setGenerationMessage("");
                 }}
               >
                 <div className="mb-2 flex items-center justify-between gap-3">
@@ -342,15 +385,30 @@ export function DistillPage({
               这份内容来自你选中的 {selectedThoughts.length} 条记录，可以继续编辑后保存。
             </p>
           </div>
-          <button
-            className="inline-flex items-center justify-center gap-2 rounded-md bg-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black disabled:bg-stone-200 disabled:text-muted"
-            disabled={selectedThoughts.length === 0}
-            type="button"
-            onClick={saveDraft}
-          >
-            <Save size={16} strokeWidth={1.8} />
-            {activeDraftId ? "更新草稿" : "保存草稿"}
-          </button>
+          <div className="flex flex-wrap gap-2 sm:justify-end">
+            <button
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-line bg-canvas px-4 py-2 text-sm font-medium text-ink transition hover:bg-white disabled:bg-stone-100 disabled:text-muted"
+              disabled={selectedThoughts.length === 0 || isGenerating}
+              type="button"
+              onClick={() => void generateDistill()}
+            >
+              {isGenerating ? (
+                <LoaderCircle className="animate-spin" size={16} strokeWidth={1.8} />
+              ) : (
+                <Sparkles size={16} strokeWidth={1.8} />
+              )}
+              {isGenerating ? "生成中" : "AI 生成"}
+            </button>
+            <button
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-ink px-4 py-2 text-sm font-medium text-white transition hover:bg-black disabled:bg-stone-200 disabled:text-muted"
+              disabled={selectedThoughts.length === 0}
+              type="button"
+              onClick={saveDraft}
+            >
+              <Save size={16} strokeWidth={1.8} />
+              {activeDraftId ? "更新草稿" : "保存草稿"}
+            </button>
+          </div>
         </div>
 
         <div className="mb-4 flex flex-wrap gap-2">
@@ -366,6 +424,7 @@ export function DistillPage({
               onClick={() => {
                 setActiveDraftId(null);
                 setOutputType(type);
+                setGenerationMessage("");
               }}
             >
               {type}
@@ -380,6 +439,12 @@ export function DistillPage({
             topics={topics}
           />
         </div>
+
+        {generationMessage && (
+          <div className="mb-4 rounded-lg border border-sage/20 bg-sage/10 px-4 py-3 text-sm leading-6 text-ink">
+            {generationMessage}
+          </div>
+        )}
 
         <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-ink">
           <FilePenLine size={16} strokeWidth={1.8} />

--- a/src/services/distillRepository.ts
+++ b/src/services/distillRepository.ts
@@ -1,0 +1,63 @@
+import { getSupabaseClient } from "./supabaseClient";
+import type { DistillOutputType, Thought, Topic } from "../types";
+
+export interface CloudDistillResult {
+  title: string;
+  content: string;
+}
+
+interface GenerateCloudDistillParams {
+  outputType: DistillOutputType;
+  topic: Topic;
+  thoughts: Thought[];
+}
+
+function compactThought(thought: Thought) {
+  return {
+    id: thought.id,
+    content: thought.content,
+    summary: thought.summary,
+    source: thought.source,
+    createdAt: thought.createdAt,
+    questions: thought.questions,
+    status: thought.status,
+  };
+}
+
+export async function generateCloudDistill({
+  outputType,
+  topic,
+  thoughts,
+}: GenerateCloudDistillParams): Promise<CloudDistillResult | null> {
+  const supabase = await getSupabaseClient();
+  if (!supabase) return null;
+
+  const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+  if (sessionError) throw sessionError;
+  if (!sessionData.session) return null;
+
+  const { data, error } = await supabase.functions.invoke("distill", {
+    body: {
+      outputType,
+      topic: {
+        id: topic.id,
+        name: topic.name,
+        summary: topic.summary,
+        description: topic.description,
+      },
+      thoughts: thoughts.map(compactThought),
+    },
+  });
+
+  if (error) throw error;
+
+  const result = data as Partial<CloudDistillResult> | null;
+  if (!result?.content || !result?.title) {
+    throw new Error("Distill function returned an invalid result.");
+  }
+
+  return {
+    title: result.title,
+    content: result.content,
+  };
+}

--- a/supabase/functions/distill/index.ts
+++ b/supabase/functions/distill/index.ts
@@ -1,0 +1,146 @@
+type DistillOutputType = "文章提纲" | "复盘框架" | "观点卡片";
+
+interface DistillThought {
+  id: string;
+  content: string;
+  summary: string;
+  source: string;
+  createdAt: string;
+  questions?: string[];
+  status?: string;
+}
+
+interface DistillTopic {
+  id: string;
+  name: string;
+  summary: string;
+  description: string;
+}
+
+interface DistillRequestBody {
+  outputType?: DistillOutputType;
+  topic?: DistillTopic;
+  thoughts?: DistillThought[];
+}
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function buildPrompt(outputType: DistillOutputType, topic: DistillTopic, thoughts: DistillThought[]) {
+  const sources = thoughts
+    .map((thought, index) => {
+      return [
+        `来源 ${index + 1}`,
+        `摘要：${thought.summary}`,
+        `原文：${thought.content}`,
+        thought.questions?.length ? `问题：${thought.questions.join("；")}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n\n");
+
+  return `你是 QuantumX 的个人思考蒸馏助手。请只基于用户提供的历史记录生成内容，不要编造来源之外的信息。
+
+主题：${topic.name}
+主题摘要：${topic.summary}
+主题说明：${topic.description}
+输出类型：${outputType}
+
+来源记录：
+${sources}
+
+要求：
+1. 使用中文。
+2. 输出 Markdown。
+3. 保留个人思考语气，不要写成营销文。
+4. 内容要具体、可编辑、有结构。
+5. 如果是文章提纲，输出标题、核心观点、3-5 个章节和可继续追问的问题。
+6. 如果是复盘框架，输出事实、感受、模式、下一步动作。
+7. 如果是观点卡片，输出 3-5 张观点卡片，每张包含观点、依据和可延展方向。`;
+}
+
+async function generateWithOpenAI(prompt: string) {
+  const apiKey = Deno.env.get("OPENAI_API_KEY");
+  const model = Deno.env.get("OPENAI_DISTILL_MODEL") ?? "gpt-4.1-mini";
+
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not configured.");
+  }
+
+  const response = await fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      input: prompt,
+      temperature: 0.5,
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`OpenAI request failed: ${response.status} ${detail}`);
+  }
+
+  const data = await response.json();
+  const content = data.output_text;
+
+  if (typeof content !== "string" || content.trim().length === 0) {
+    throw new Error("OpenAI response did not include output_text.");
+  }
+
+  return content.trim();
+}
+
+Deno.serve(async (request) => {
+  if (request.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (request.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
+  }
+
+  try {
+    const body = (await request.json()) as DistillRequestBody;
+    const outputType = body.outputType;
+    const topic = body.topic;
+    const thoughts = body.thoughts ?? [];
+
+    if (!outputType || !topic || thoughts.length === 0) {
+      return jsonResponse({ error: "Missing outputType, topic, or thoughts." }, 400);
+    }
+
+    const prompt = buildPrompt(outputType, topic, thoughts);
+    const content = await generateWithOpenAI(prompt);
+
+    return jsonResponse({
+      title: `${topic.name} · ${outputType}`,
+      content,
+    });
+  } catch (error) {
+    console.error(error);
+    return jsonResponse(
+      {
+        error: error instanceof Error ? error.message : "Unknown distill error",
+      },
+      500,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- Add a Supabase Edge Function `distill` for server-side AI-generated Markdown output.
- Add a frontend distill client that invokes the Edge Function when the user is logged in.
- Add an "AI 生成" button on the Distill page while preserving the existing local template fallback.
- Keep existing save/edit/copy draft behavior unchanged.

## Notes

To enable real AI generation, configure Supabase function secrets:

```bash
supabase secrets set OPENAI_API_KEY=...
supabase secrets set OPENAI_DISTILL_MODEL=gpt-4.1-mini
```

If the Edge Function or API key is not configured, the UI falls back to the current local template generation.

## Verification

- Not run in this environment. Please run `npm run build` and `npm run lint` locally or via CI.