### PR TITLE
[codex] Enhance data sync trust layer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -682,7 +682,13 @@ export default function App() {
 
   useEffect(() => {
     if (snapshotScope !== currentStorageScope) return;
-    void localQuantumXRepository.saveSnapshot(currentSnapshot);
+    void localQuantumXRepository.saveSnapshot(currentSnapshot).then(() => {
+      setCloudMetadataScope(currentStorageScope);
+      setCloudSyncMetadata((current) => ({
+        ...current,
+        lastLocalSavedAt: new Date().toISOString(),
+      }));
+    });
   }, [currentSnapshot, currentStorageScope, localQuantumXRepository, snapshotScope]);
 
   useEffect(() => {

--- a/src/components/CloudModePanel.tsx
+++ b/src/components/CloudModePanel.tsx
@@ -264,7 +264,7 @@ export function CloudModePanel({
       : "暂无云端摘要";
 
     return window.confirm(
-      `准备把本地数据上传到云端。\n\n本地：${localSummary.thoughts} 条记录、${localSummary.topics} 个主题、${localSummary.drafts} 份草稿\n云端：${cloudText}\n\n已存在的同 client_id 数据会被更新。确认继续吗？`,
+      `准备把本地数据上传/更新到云端。\n\n本地：${localSummary.thoughts} 条记录、${localSummary.topics} 个主题、${localSummary.drafts} 份草稿\n云端：${cloudText}\n\n这会新增或更新同 client_id 的记录、主题和草稿，但不会自动删除云端已有的其他旧数据。建议先下载 JSON 备份。确认继续吗？`,
     );
   }
 
@@ -274,7 +274,7 @@ export function CloudModePanel({
       : "暂无云端摘要";
 
     return window.confirm(
-      `准备从云端恢复数据到当前浏览器。\n\n本地：${localSummary.thoughts} 条记录、${localSummary.topics} 个主题、${localSummary.drafts} 份草稿\n云端：${cloudText}\n\n这会覆盖当前浏览器里的本地数据。建议先下载备份。确认继续吗？`,
+      `准备从云端恢复数据到当前浏览器。\n\n本地：${localSummary.thoughts} 条记录、${localSummary.topics} 个主题、${localSummary.drafts} 份草稿\n云端：${cloudText}\n\n从云端恢复会覆盖当前浏览器本地数据，但不会删除云端数据。建议先下载 JSON 备份。确认继续吗？`,
     );
   }
 
@@ -463,7 +463,7 @@ export function CloudModePanel({
 
     const detail =
       localCount > 0 && cloudCount > 0
-        ? "如果这台设备上的内容是最新的，就先同步到云端；如果你之前在别的设备上已经整理过内容，就先从云端恢复。"
+        ? "如果这台设备上的内容是最新的，就先上传/更新到云端；如果你之前在别的设备上已经整理过内容，就先从云端恢复。"
         : localCount > 0
           ? "这样这台设备里的记录、主题和草稿会成为你的第一份云端副本。"
           : cloudCount > 0
@@ -486,7 +486,7 @@ export function CloudModePanel({
             onClick={() => void syncToCloud()}
           >
             <CloudUpload size={15} strokeWidth={1.8} />
-            把这台设备同步到云端
+            上传/更新到云端
           </button>
           <button
             className="theme-button-muted inline-flex items-center gap-2 rounded-xl px-3.5 py-2.5 text-sm transition disabled:opacity-60"
@@ -638,7 +638,7 @@ export function CloudModePanel({
               onClick={() => void syncToCloud()}
             >
               <CloudUpload size={15} strokeWidth={1.8} />
-              同步到云端
+              上传/更新到云端
             </button>
             <button
               className="theme-button-secondary inline-flex items-center gap-2 rounded-xl px-3.5 py-2.5 text-sm transition disabled:opacity-60"

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -355,6 +355,7 @@ export function normalizeCloudSyncMetadata(
   if (!metadata || typeof metadata !== "object") return {};
 
   return {
+    lastLocalSavedAt: normalizeOptionalIsoDate(metadata.lastLocalSavedAt),
     lastPushedAt: normalizeOptionalIsoDate(metadata.lastPushedAt),
     lastPulledAt: normalizeOptionalIsoDate(metadata.lastPulledAt),
     lastKnownCloudSummary: normalizeSnapshotSummary(metadata.lastKnownCloudSummary),

--- a/src/pages/DataPage.tsx
+++ b/src/pages/DataPage.tsx
@@ -88,6 +88,9 @@ export function DataPage({
   const dataSize = getStorageSizeLabel(snapshot);
   const lastCloudEventAt =
     cloudSyncMetadata.lastPushedAt ?? cloudSyncMetadata.lastPulledAt;
+  const lastLocalSavedLabel = cloudSyncMetadata.lastLocalSavedAt
+    ? formatDateTime(cloudSyncMetadata.lastLocalSavedAt)
+    : "还没有本地保存记录";
 
   function renderSyncStatus() {
     if (dataMode === "local" || cloudSyncState === "local") {
@@ -95,7 +98,9 @@ export function DataPage({
         icon: CloudOff,
         tone: "border-line theme-surface-ghost text-muted",
         title: "当前是本地模式",
-        detail: "记录会先保存在这个浏览器里。登录并同步后，才会开始跟随云端。",
+        detail: cloudSyncMetadata.lastLocalSavedAt
+          ? `记录已保存在这个浏览器里，最近本地保存：${lastLocalSavedLabel}。登录并上传后，才会开始跟随云端。`
+          : "记录会先保存在这个浏览器里。登录并上传后，才会开始跟随云端。",
       };
     }
 
@@ -259,6 +264,7 @@ export function DataPage({
                   ? new Date(latestThought.createdAt).toLocaleDateString("zh-CN")
                   : "暂无"}
               </span>
+              <span>最近本地保存：{lastLocalSavedLabel}</span>
             </div>
           </div>
 
@@ -321,12 +327,12 @@ export function DataPage({
           <div className="frost-panel rounded-[26px] p-5">
             <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-ink">
               <CheckCircle2 size={16} strokeWidth={1.8} />
-              下一步落地
+              下一步增强
             </div>
             <div className="space-y-3 text-sm leading-6 text-muted">
-              <p>1. 接入账号和云数据库，让记录跟随用户。</p>
-              <p>2. 用向量检索做真实相关旧想法召回。</p>
-              <p>3. 保存每次 AI 蒸馏的来源和用户反馈。</p>
+              <p>1. 增加导入前预览，避免误覆盖当前浏览器数据。</p>
+              <p>2. 明确区分“上传更新”和“完整替换”，减少同步误解。</p>
+              <p>3. 补齐账号删除、数据清除和隐私说明。</p>
             </div>
           </div>
         </aside>

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,7 @@ export interface QuantumXDataExport {
 }
 
 export interface CloudSyncMetadata {
+  lastLocalSavedAt?: string;
   lastPushedAt?: string;
   lastPulledAt?: string;
   lastKnownCloudSummary?: SnapshotSummary;


### PR DESCRIPTION
## Summary
- add lastLocalSavedAt metadata and persist it after local snapshot saves
- show recent local save time on the Data page and local mode status
- clarify cloud upload/update copy so users know upsert does not delete extra cloud records

## Checks
- npm run lint
- npm run build