### PR TITLE
[codex] Add JSON import preview

### DIFF
--- a/src/pages/DataPage.tsx
+++ b/src/pages/DataPage.tsx
@@ -72,6 +72,9 @@ export function DataPage({
 }: DataPageProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [importMessage, setImportMessage] = useState("");
+  const [pendingImport, setPendingImport] =
+    useState<QuantumXDataSnapshot | null>(null);
+  const [pendingImportName, setPendingImportName] = useState("");
   const snapshot = useMemo(
     () => ({ thoughts, topics, savedDistills, captureDraft }),
     [captureDraft, savedDistills, thoughts, topics],
@@ -159,19 +162,38 @@ export function DataPage({
     try {
       const raw = await file.text();
       const imported = parseDataExport(raw);
-      const confirmed = window.confirm(
-        "导入备份会覆盖当前浏览器里的 QuantumX 本地数据。确认继续吗？",
-      );
-      if (!confirmed) return;
-      onImportData(imported);
-      setImportMessage(
-        `已导入 ${imported.thoughts.length} 条记录、${imported.topics.length} 个主题和 ${imported.savedDistills.length} 份草稿。`,
-      );
+      setPendingImport(imported);
+      setPendingImportName(file.name);
+      setImportMessage("");
     } catch {
+      setPendingImport(null);
+      setPendingImportName("");
       setImportMessage("这个文件暂时无法识别。请确认它是 QuantumX 导出的 JSON 备份。");
-    } finally {
       if (inputRef.current) inputRef.current.value = "";
     }
+  }
+
+  function confirmPendingImport() {
+    if (!pendingImport) return;
+
+    const confirmed = window.confirm(
+      "导入备份会覆盖当前浏览器里的 QuantumX 本地数据。确认继续吗？",
+    );
+    if (!confirmed) return;
+
+    onImportData(pendingImport);
+    setImportMessage(
+      `已导入 ${pendingImport.thoughts.length} 条记录、${pendingImport.topics.length} 个主题和 ${pendingImport.savedDistills.length} 份草稿。`,
+    );
+    setPendingImport(null);
+    setPendingImportName("");
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  function cancelPendingImport() {
+    setPendingImport(null);
+    setPendingImportName("");
+    if (inputRef.current) inputRef.current.value = "";
   }
 
   return (
@@ -290,6 +312,52 @@ export function DataPage({
               }}
             />
           </div>
+
+          {pendingImport && (
+            <div className="theme-card-soft mt-4 rounded-[22px] px-4 py-4 text-sm leading-6 text-muted">
+              <div className="mb-3 flex items-start gap-3">
+                <div className="theme-icon-soft mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl">
+                  <FileUp size={16} strokeWidth={1.8} />
+                </div>
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold text-ink">导入前预览</div>
+                  <div className="mt-1 break-all text-xs text-muted">
+                    文件名：{pendingImportName || "未命名 JSON 文件"}
+                  </div>
+                </div>
+              </div>
+              <div className="theme-card-overlay rounded-[18px] px-3.5 py-3">
+                <div>
+                  将导入：{pendingImport.thoughts.length} 条记录、
+                  {pendingImport.topics.length} 个主题、
+                  {pendingImport.savedDistills.length} 份草稿
+                </div>
+                <div className="mt-1">
+                  未提交草稿：
+                  {pendingImport.captureDraft.trim() ? "有" : "无"}
+                </div>
+              </div>
+              <p className="mt-3 text-xs leading-6 text-muted">
+                导入会覆盖当前浏览器里的本地数据，建议先下载备份。
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  className="theme-primary-button rounded-xl px-3.5 py-2.5 text-sm font-medium transition"
+                  type="button"
+                  onClick={confirmPendingImport}
+                >
+                  确认导入并覆盖
+                </button>
+                <button
+                  className="theme-button-muted rounded-xl px-3.5 py-2.5 text-sm transition"
+                  type="button"
+                  onClick={cancelPendingImport}
+                >
+                  取消
+                </button>
+              </div>
+            </div>
+          )}
 
           {importMessage && (
             <div className="theme-accent-soft mt-4 rounded-lg px-4 py-3 text-sm leading-6">


### PR DESCRIPTION
## Summary
- parse selected QuantumX JSON backups into a pending import state instead of importing immediately
- show a preview card with file name, counts, and capture draft presence
- require explicit confirm import action before overwriting current browser data

## Checks
- npm run lint
- npm run build