### PR TITLE
[codex] Add shared memory match card

### DIFF
--- a/src/components/MemoryMatchCard.tsx
+++ b/src/components/MemoryMatchCard.tsx
@@ -1,0 +1,60 @@
+import { ArrowRight, Clock3 } from "lucide-react";
+import { formatMonthDay } from "../lib/date";
+import type { MemoryMatch, MemoryMatchKind } from "../types";
+
+interface MemoryMatchCardProps {
+  match: MemoryMatch;
+  onOpenThought?: (thoughtId: string) => void;
+  compact?: boolean;
+}
+
+const kindLabels: Record<MemoryMatchKind, string> = {
+  direct: "直接相关",
+  similar: "相似想法",
+  counterpoint: "反向观点",
+};
+
+export function MemoryMatchCard({
+  match,
+  onOpenThought,
+  compact = false,
+}: MemoryMatchCardProps) {
+  return (
+    <article className="theme-card-soft rounded-[20px] p-3.5 text-left">
+      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-muted">
+        <span className="theme-pill rounded-full px-2 py-0.5">
+          {kindLabels[match.kind]}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <Clock3 size={13} strokeWidth={1.8} />
+          {formatMonthDay(match.thought.createdAt)}
+        </span>
+      </div>
+
+      <div className="text-sm font-semibold leading-6 text-ink">
+        {match.thought.summary}
+      </div>
+      <p
+        className={`mt-1 text-sm leading-6 text-muted ${
+          compact ? "line-clamp-2" : "line-clamp-4"
+        }`}
+      >
+        {match.thought.content}
+      </p>
+      <div className="theme-card-overlay mt-3 rounded-[16px] px-3 py-2 text-xs leading-5 text-muted">
+        {match.reason}
+      </div>
+
+      {onOpenThought && (
+        <button
+          className="theme-button-muted mt-3 inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs transition"
+          type="button"
+          onClick={() => onOpenThought(match.thought.id)}
+        >
+          打开
+          <ArrowRight size={13} strokeWidth={1.8} />
+        </button>
+      )}
+    </article>
+  );
+}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -10,7 +10,7 @@ import {
   Sparkles,
   X,
 } from "lucide-react";
-import { MemoryRecallExplanation } from "../components/MemoryRecallExplanation";
+import { MemoryMatchCard } from "../components/MemoryMatchCard";
 import { TopicBadge } from "../components/TopicBadge";
 import { formatMonthDay } from "../lib/date";
 import {
@@ -463,7 +463,13 @@ export function SearchPage({
                     </div>
 
                     {semanticMatch && (
-                      <MemoryRecallExplanation match={semanticMatch} topics={topics} />
+                      <div className="mt-4">
+                        <MemoryMatchCard
+                          compact
+                          match={semanticMatch}
+                          onOpenThought={onOpenThought}
+                        />
+                      </div>
                     )}
 
                     {sourceThought && (


### PR DESCRIPTION
## Summary
- add a reusable MemoryMatchCard component for related memory display
- show match summary, content, reason, kind label, date, and optional open action
- use the new card in SearchPage for semantic recall matches without changing recall ranking or feedback logic

## Checks
- npm run lint
- npm run build