### PR TITLE
[codex] Add memory match feedback controls

### DIFF
--- a/src/components/MemoryMatchCard.tsx
+++ b/src/components/MemoryMatchCard.tsx
@@ -1,10 +1,17 @@
 import { ArrowRight, Clock3 } from "lucide-react";
 import { formatMonthDay } from "../lib/date";
-import type { MemoryMatch, MemoryMatchKind } from "../types";
+import type {
+  MemoryFeedbackType,
+  MemoryMatch,
+  MemoryMatchKind,
+} from "../types";
 
 interface MemoryMatchCardProps {
   match: MemoryMatch;
   onOpenThought?: (thoughtId: string) => void;
+  onFeedback?: (thoughtId: string, feedback: MemoryFeedbackType) => void;
+  selectedFeedback?: MemoryFeedbackType | null;
+  showFeedback?: boolean;
   compact?: boolean;
 }
 
@@ -14,9 +21,21 @@ const kindLabels: Record<MemoryMatchKind, string> = {
   counterpoint: "反向观点",
 };
 
+const feedbackOptions: Array<{
+  label: string;
+  value: MemoryFeedbackType;
+}> = [
+  { label: "有帮助", value: "helpful" },
+  { label: "不相关", value: "irrelevant" },
+  { label: "同一主题", value: "same_topic" },
+];
+
 export function MemoryMatchCard({
   match,
   onOpenThought,
+  onFeedback,
+  selectedFeedback = null,
+  showFeedback = false,
   compact = false,
 }: MemoryMatchCardProps) {
   return (
@@ -45,15 +64,37 @@ export function MemoryMatchCard({
         {match.reason}
       </div>
 
-      {onOpenThought && (
-        <button
-          className="theme-button-muted mt-3 inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs transition"
-          type="button"
-          onClick={() => onOpenThought(match.thought.id)}
-        >
-          打开
-          <ArrowRight size={13} strokeWidth={1.8} />
-        </button>
+      {(onOpenThought || showFeedback) && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {onOpenThought && (
+            <button
+              className="theme-button-muted inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs transition"
+              type="button"
+              onClick={() => onOpenThought(match.thought.id)}
+            >
+              打开
+              <ArrowRight size={13} strokeWidth={1.8} />
+            </button>
+          )}
+          {showFeedback &&
+            feedbackOptions.map((option) => {
+              const selected = selectedFeedback === option.value;
+              return (
+                <button
+                  key={option.value}
+                  className={`rounded-xl px-3 py-2 text-xs transition ${
+                    selected
+                      ? "theme-accent-soft font-medium text-ink"
+                      : "theme-button-muted"
+                  }`}
+                  type="button"
+                  onClick={() => onFeedback?.(match.thought.id, option.value)}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+        </div>
       )}
     </article>
   );

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -155,6 +155,9 @@ export function SearchPage({
   const [recallStrategy, setRecallStrategy] = useState<RecallStrategy>("local");
   const [recallLoading, setRecallLoading] = useState(false);
   const [feedback, setFeedback] = useState<Record<string, MemoryFeedbackType>>({});
+  const [memoryFeedbackByThoughtId, setMemoryFeedbackByThoughtId] = useState<
+    Record<string, MemoryFeedbackType>
+  >({});
   const [pinnedIds, setPinnedIds] = useState<string[]>([]);
   const [expandedActionIds, setExpandedActionIds] = useState<string[]>([]);
   const suggestions = useMemo(
@@ -467,6 +470,16 @@ export function SearchPage({
                         <MemoryMatchCard
                           compact
                           match={semanticMatch}
+                          selectedFeedback={
+                            memoryFeedbackByThoughtId[semanticMatch.thought.id] ?? null
+                          }
+                          showFeedback
+                          onFeedback={(thoughtId, nextFeedback) =>
+                            setMemoryFeedbackByThoughtId((current) => ({
+                              ...current,
+                              [thoughtId]: nextFeedback,
+                            }))
+                          }
                           onOpenThought={onOpenThought}
                         />
                       </div>


### PR DESCRIPTION
## Summary
- add optional local feedback controls to MemoryMatchCard
- support selected feedback styling for helpful, irrelevant, and same-topic responses
- wire SearchPage semantic recall cards to local feedback state without cloud writes

## Checks
- npm run lint
- npm run build