### PR TITLE
[codex] Wire memory card feedback on today and detail

### DIFF
--- a/src/pages/ThoughtDetailPage.tsx
+++ b/src/pages/ThoughtDetailPage.tsx
@@ -19,7 +19,14 @@ import {
   type RecallSource,
   type RecallStrategy,
 } from "../services/recallRepository";
-import type { MemoryMatch, Thought, ThoughtStatus, Topic } from "../types";
+import { recordMemoryFeedback } from "../services/memoryFeedbackRepository";
+import type {
+  MemoryFeedbackType,
+  MemoryMatch,
+  Thought,
+  ThoughtStatus,
+  Topic,
+} from "../types";
 
 interface ThoughtDetailPageProps {
   thought: Thought;
@@ -75,6 +82,9 @@ export function ThoughtDetailPage({
   const [recallSource, setRecallSource] = useState<RecallSource>("local");
   const [recallStrategy, setRecallStrategy] = useState<RecallStrategy>("local");
   const [recallLoading, setRecallLoading] = useState(false);
+  const [memoryFeedback, setMemoryFeedback] = useState<
+    Record<string, MemoryFeedbackType>
+  >({});
 
   useEffect(() => {
     setContentDraft(thought.content);
@@ -123,6 +133,24 @@ export function ThoughtDetailPage({
     );
   }
 
+  async function persistMemoryFeedback(
+    thoughtId: string,
+    feedbackType: MemoryFeedbackType,
+  ) {
+    setMemoryFeedback((current) => ({
+      ...current,
+      [thoughtId]: feedbackType,
+    }));
+    await recordMemoryFeedback({
+      feedbackType,
+      sourceThoughtId: thought.id,
+      targetThoughtId: thoughtId,
+      context: thought.content,
+    }).catch(() => {
+      // Keep detail feedback lightweight even when cloud writes fail.
+    });
+  }
+
   function renderRelatedMemories() {
     const recallLabel = recallLoading
       ? "匹配中"
@@ -150,6 +178,11 @@ export function ThoughtDetailPage({
                   key={match.thought.id}
                   compact
                   match={match}
+                  selectedFeedback={memoryFeedback[match.thought.id] ?? null}
+                  showFeedback
+                  onFeedback={(thoughtId, feedbackType) => {
+                    void persistMemoryFeedback(thoughtId, feedbackType);
+                  }}
                   onOpenThought={onOpenThought}
                 />
               ))}

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -9,7 +9,8 @@ import {
   type RecallSource,
   type RecallStrategy,
 } from "../services/recallRepository";
-import type { MemoryMatch, Thought, Topic } from "../types";
+import { recordMemoryFeedback } from "../services/memoryFeedbackRepository";
+import type { MemoryFeedbackType, MemoryMatch, Thought, Topic } from "../types";
 
 interface TodayPageProps {
   draft: string;
@@ -59,6 +60,9 @@ export function TodayPage({
   const [recallSource, setRecallSource] = useState<RecallSource>("local");
   const [recallStrategy, setRecallStrategy] = useState<RecallStrategy>("local");
   const [recallLoading, setRecallLoading] = useState(false);
+  const [memoryFeedback, setMemoryFeedback] = useState<
+    Record<string, MemoryFeedbackType>
+  >({});
 
   useEffect(() => {
     let cancelled = false;
@@ -110,6 +114,24 @@ export function TodayPage({
     thoughts[0];
   const briefTopic = topics.find((topic) => briefThought?.topicIds.includes(topic.id));
 
+  async function persistMemoryFeedback(
+    thoughtId: string,
+    feedbackType: MemoryFeedbackType,
+  ) {
+    setMemoryFeedback((current) => ({
+      ...current,
+      [thoughtId]: feedbackType,
+    }));
+    await recordMemoryFeedback({
+      feedbackType,
+      sourceThoughtId: thoughts[0]?.id,
+      targetThoughtId: thoughtId,
+      context: draft.trim() || thoughts[0]?.content || "today",
+    }).catch(() => {
+      // Keep today feedback lightweight even when cloud writes fail.
+    });
+  }
+
   function renderRelatedMemories() {
     const recallLabel = recallLoading
       ? "匹配中"
@@ -137,6 +159,11 @@ export function TodayPage({
                   key={match.thought.id}
                   compact
                   match={match}
+                  selectedFeedback={memoryFeedback[match.thought.id] ?? null}
+                  showFeedback
+                  onFeedback={(thoughtId, feedbackType) => {
+                    void persistMemoryFeedback(thoughtId, feedbackType);
+                  }}
                   onOpenThought={onOpenThought}
                 />
               ))}


### PR DESCRIPTION
## Summary
- add local MemoryMatchCard feedback state to TodayPage and ThoughtDetailPage
- route feedback clicks through the existing memory_feedback repository
- preserve recall ordering, capture flow, and MemoryMatchCard props

## Checks
- npm run lint
- npm run build