### PR TITLE
[codex] Extract memory feedback hook

### DIFF
--- a/src/hooks/useMemoryFeedback.ts
+++ b/src/hooks/useMemoryFeedback.ts
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { recordMemoryFeedback } from "../services/memoryFeedbackRepository";
+import type { MemoryFeedbackType } from "../types";
+
+interface PersistFeedbackParams {
+  feedbackType: MemoryFeedbackType;
+  sourceThoughtId?: string;
+  context?: string;
+}
+
+export function useMemoryFeedback() {
+  const [feedback, setFeedback] = useState<Record<string, MemoryFeedbackType>>({});
+
+  async function persistFeedback(
+    thoughtId: string,
+    params: PersistFeedbackParams,
+  ) {
+    setFeedback((current) => ({
+      ...current,
+      [thoughtId]: params.feedbackType,
+    }));
+
+    await recordMemoryFeedback({
+      feedbackType: params.feedbackType,
+      sourceThoughtId: params.sourceThoughtId,
+      targetThoughtId: thoughtId,
+      context: params.context,
+    }).catch(() => {
+      // Keep feedback lightweight when cloud writes fail.
+    });
+  }
+
+  return { feedback, persistFeedback };
+}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -25,9 +25,8 @@ import {
   type RecallSource,
   type RecallStrategy,
 } from "../services/recallRepository";
-import { recordMemoryFeedback } from "../services/memoryFeedbackRepository";
+import { useMemoryFeedback } from "../hooks/useMemoryFeedback";
 import type {
-  MemoryFeedbackType,
   MemoryMatch,
   SavedDistill,
   Thought,
@@ -154,7 +153,7 @@ export function SearchPage({
   const [recallSource, setRecallSource] = useState<RecallSource>("local");
   const [recallStrategy, setRecallStrategy] = useState<RecallStrategy>("local");
   const [recallLoading, setRecallLoading] = useState(false);
-  const [feedback, setFeedback] = useState<Record<string, MemoryFeedbackType>>({});
+  const { feedback, persistFeedback } = useMemoryFeedback();
   const [pinnedIds, setPinnedIds] = useState<string[]>([]);
   const [expandedActionIds, setExpandedActionIds] = useState<string[]>([]);
   const suggestions = useMemo(
@@ -224,25 +223,14 @@ export function SearchPage({
     onNavigateDistill();
   }
 
-  function persistFeedback(thoughtId: string, feedbackType: MemoryFeedbackType) {
-    setFeedback((current) => ({
-      ...current,
-      [thoughtId]: feedbackType,
-    }));
-    void recordMemoryFeedback({
-      feedbackType,
-      targetThoughtId: thoughtId,
-      context: query,
-    }).catch(() => {
-      // Search feedback should stay lightweight even when cloud writes fail.
-    });
-  }
-
   function togglePinned(thoughtId: string) {
     setPinnedIds((current) => {
       const alreadyPinned = current.includes(thoughtId);
       if (alreadyPinned) return current.filter((id) => id !== thoughtId);
-      persistFeedback(thoughtId, "pinned");
+      void persistFeedback(thoughtId, {
+        feedbackType: "pinned",
+        context: query,
+      });
       return [thoughtId, ...current];
     });
   }
@@ -470,7 +458,10 @@ export function SearchPage({
                           selectedFeedback={feedback[semanticMatch.thought.id] ?? null}
                           showFeedback
                           onFeedback={(thoughtId, nextFeedback) => {
-                            persistFeedback(thoughtId, nextFeedback);
+                            void persistFeedback(thoughtId, {
+                              feedbackType: nextFeedback,
+                              context: query,
+                            });
                           }}
                           onOpenThought={onOpenThought}
                         />
@@ -506,7 +497,12 @@ export function SearchPage({
                                 : "theme-button-muted"
                             }`}
                             type="button"
-                            onClick={() => persistFeedback(sourceThought.id, "helpful")}
+                            onClick={() =>
+                              void persistFeedback(sourceThought.id, {
+                                feedbackType: "helpful",
+                                context: query,
+                              })
+                            }
                           >
                             <Check size={13} strokeWidth={1.8} />
                             有帮助
@@ -518,7 +514,12 @@ export function SearchPage({
                                 : "theme-button-muted"
                             }`}
                             type="button"
-                            onClick={() => persistFeedback(sourceThought.id, "irrelevant")}
+                            onClick={() =>
+                              void persistFeedback(sourceThought.id, {
+                                feedbackType: "irrelevant",
+                                context: query,
+                              })
+                            }
                           >
                             <X size={13} strokeWidth={1.8} />
                             不相关
@@ -541,7 +542,12 @@ export function SearchPage({
                                   : "theme-button-muted"
                               }`}
                               type="button"
-                              onClick={() => persistFeedback(sourceThought.id, "same_topic")}
+                              onClick={() =>
+                                void persistFeedback(sourceThought.id, {
+                                  feedbackType: "same_topic",
+                                  context: query,
+                                })
+                              }
                             >
                               标记同主题
                             </button>

--- a/src/pages/ThoughtDetailPage.tsx
+++ b/src/pages/ThoughtDetailPage.tsx
@@ -19,9 +19,8 @@ import {
   type RecallSource,
   type RecallStrategy,
 } from "../services/recallRepository";
-import { recordMemoryFeedback } from "../services/memoryFeedbackRepository";
+import { useMemoryFeedback } from "../hooks/useMemoryFeedback";
 import type {
-  MemoryFeedbackType,
   MemoryMatch,
   Thought,
   ThoughtStatus,
@@ -82,9 +81,7 @@ export function ThoughtDetailPage({
   const [recallSource, setRecallSource] = useState<RecallSource>("local");
   const [recallStrategy, setRecallStrategy] = useState<RecallStrategy>("local");
   const [recallLoading, setRecallLoading] = useState(false);
-  const [memoryFeedback, setMemoryFeedback] = useState<
-    Record<string, MemoryFeedbackType>
-  >({});
+  const { feedback: memoryFeedback, persistFeedback } = useMemoryFeedback();
 
   useEffect(() => {
     setContentDraft(thought.content);
@@ -133,24 +130,6 @@ export function ThoughtDetailPage({
     );
   }
 
-  async function persistMemoryFeedback(
-    thoughtId: string,
-    feedbackType: MemoryFeedbackType,
-  ) {
-    setMemoryFeedback((current) => ({
-      ...current,
-      [thoughtId]: feedbackType,
-    }));
-    await recordMemoryFeedback({
-      feedbackType,
-      sourceThoughtId: thought.id,
-      targetThoughtId: thoughtId,
-      context: thought.content,
-    }).catch(() => {
-      // Keep detail feedback lightweight even when cloud writes fail.
-    });
-  }
-
   function renderRelatedMemories() {
     const recallLabel = recallLoading
       ? "匹配中"
@@ -181,7 +160,11 @@ export function ThoughtDetailPage({
                   selectedFeedback={memoryFeedback[match.thought.id] ?? null}
                   showFeedback
                   onFeedback={(thoughtId, feedbackType) => {
-                    void persistMemoryFeedback(thoughtId, feedbackType);
+                    void persistFeedback(thoughtId, {
+                      feedbackType,
+                      sourceThoughtId: thought.id,
+                      context: thought.content,
+                    });
                   }}
                   onOpenThought={onOpenThought}
                 />

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -9,8 +9,8 @@ import {
   type RecallSource,
   type RecallStrategy,
 } from "../services/recallRepository";
-import { recordMemoryFeedback } from "../services/memoryFeedbackRepository";
-import type { MemoryFeedbackType, MemoryMatch, Thought, Topic } from "../types";
+import { useMemoryFeedback } from "../hooks/useMemoryFeedback";
+import type { MemoryMatch, Thought, Topic } from "../types";
 
 interface TodayPageProps {
   draft: string;
@@ -60,9 +60,7 @@ export function TodayPage({
   const [recallSource, setRecallSource] = useState<RecallSource>("local");
   const [recallStrategy, setRecallStrategy] = useState<RecallStrategy>("local");
   const [recallLoading, setRecallLoading] = useState(false);
-  const [memoryFeedback, setMemoryFeedback] = useState<
-    Record<string, MemoryFeedbackType>
-  >({});
+  const { feedback: memoryFeedback, persistFeedback } = useMemoryFeedback();
 
   useEffect(() => {
     let cancelled = false;
@@ -114,24 +112,6 @@ export function TodayPage({
     thoughts[0];
   const briefTopic = topics.find((topic) => briefThought?.topicIds.includes(topic.id));
 
-  async function persistMemoryFeedback(
-    thoughtId: string,
-    feedbackType: MemoryFeedbackType,
-  ) {
-    setMemoryFeedback((current) => ({
-      ...current,
-      [thoughtId]: feedbackType,
-    }));
-    await recordMemoryFeedback({
-      feedbackType,
-      sourceThoughtId: thoughts[0]?.id,
-      targetThoughtId: thoughtId,
-      context: draft.trim() || thoughts[0]?.content || "today",
-    }).catch(() => {
-      // Keep today feedback lightweight even when cloud writes fail.
-    });
-  }
-
   function renderRelatedMemories() {
     const recallLabel = recallLoading
       ? "匹配中"
@@ -162,7 +142,11 @@ export function TodayPage({
                   selectedFeedback={memoryFeedback[match.thought.id] ?? null}
                   showFeedback
                   onFeedback={(thoughtId, feedbackType) => {
-                    void persistMemoryFeedback(thoughtId, feedbackType);
+                    void persistFeedback(thoughtId, {
+                      feedbackType,
+                      sourceThoughtId: thoughts[0]?.id,
+                      context: draft.trim() || thoughts[0]?.content || "today",
+                    });
                   }}
                   onOpenThought={onOpenThought}
                 />


### PR DESCRIPTION
## Summary
- add a small useMemoryFeedback hook for local selected feedback state and memory_feedback writes
- migrate SearchPage, TodayPage, and ThoughtDetailPage to the hook
- preserve pinned sorting behavior, UI state, and silent cloud-write failure handling

## Checks
- npm run lint
- npm run build