### PR TITLE
[codex] Add vNext workflow helpers

### DIFF
--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -1,0 +1,69 @@
+import type { MemoryMatch, SavedDistill, Thought } from "../types";
+
+type SuggestedNextAction = "review_draft" | "organize" | "distill" | "continue";
+
+function getCreatedTime(thought: Thought) {
+  const timestamp = Date.parse(thought.createdAt);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function sortThoughtsByNewest(thoughts: Thought[]) {
+  return [...thoughts].sort((first, second) => getCreatedTime(second) - getCreatedTime(first));
+}
+
+export function getInboxThoughts(thoughts: Thought[], limit: number) {
+  return sortThoughtsByNewest(thoughts)
+    .filter((thought) => thought.status === "inbox")
+    .slice(0, limit);
+}
+
+export function getRecentThoughts(thoughts: Thought[], limit: number) {
+  return sortThoughtsByNewest(thoughts).slice(0, limit);
+}
+
+export function getRecalledThoughts(
+  matches: MemoryMatch[],
+  fallbackThoughts: Thought[],
+  limit: number,
+) {
+  const sourceThoughts =
+    matches.length > 0 ? matches.map((match) => match.thought) : fallbackThoughts;
+  const seenThoughtIds = new Set<string>();
+
+  return sourceThoughts
+    .filter((thought) => {
+      if (seenThoughtIds.has(thought.id)) {
+        return false;
+      }
+      seenThoughtIds.add(thought.id);
+      return true;
+    })
+    .slice(0, limit);
+}
+
+export function getSuggestedNextAction(
+  thought: Thought | null | undefined,
+  savedDistills: SavedDistill[],
+): SuggestedNextAction | null {
+  if (!thought) {
+    return null;
+  }
+
+  const isReferencedByDraft = savedDistills.some((draft) =>
+    draft.sourceThoughtIds?.includes(thought.id),
+  );
+
+  if (isReferencedByDraft) {
+    return "review_draft";
+  }
+
+  if (thought.topicIds.length === 0) {
+    return "organize";
+  }
+
+  if (thought.status !== "distilled") {
+    return "distill";
+  }
+
+  return "continue";
+}

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -5,6 +5,11 @@ import { MemoryMatchCard } from "../components/MemoryMatchCard";
 import { ThoughtCard } from "../components/ThoughtCard";
 import { findRelatedMemoryMatches, inferTopicIds } from "../lib/memory";
 import {
+  getInboxThoughts,
+  getRecalledThoughts,
+  getRecentThoughts,
+} from "../lib/workflow";
+import {
   fetchRelatedMemoryResult,
   type RecallSource,
   type RecallStrategy,
@@ -90,12 +95,9 @@ export function TodayPage({
     };
   }, [draft, localRelatedMatches, recallInput, thoughts, topics]);
 
-  const todayThoughts = thoughts.slice(0, 7);
-  const inboxThoughts = thoughts
-    .filter((thought) => thought.status === "inbox")
-    .slice(0, 4);
-  const recalledThoughts = relatedMatches
-    .map((match) => match.thought)
+  const todayThoughts = getRecentThoughts(thoughts, 7);
+  const inboxThoughts = getInboxThoughts(thoughts, 4);
+  const recalledThoughts = getRecalledThoughts(relatedMatches, [], relatedMatches.length)
     .filter((thought) => !todayThoughts.some((item) => item.id === thought.id))
     .slice(0, 3);
   const suggestedTopics =


### PR DESCRIPTION
## Summary
- add reusable workflow helpers for inbox, recent, recalled thoughts, and suggested next actions
- reuse the helpers in TodayPage for local thought selection without changing UI or recall behavior

## Validation
- npm run lint
- npm run build