### PR TITLE
[codex] Add Distill seed state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ import type {
 import type {
   CloudSyncState,
   CloudSyncMetadata,
+  DistillSeed,
   QuantumXDataSnapshot,
   SavedDistill,
   Thought,
@@ -133,6 +134,7 @@ export default function App() {
   const [savedDistills, setSavedDistills] = useState<SavedDistill[]>(() =>
     initialSnapshot.savedDistills,
   );
+  const [distillSeed, setDistillSeed] = useState<DistillSeed | null>(null);
   const [authState, setAuthState] = useState<AuthState>({
     configured: false,
     session: null,
@@ -197,7 +199,10 @@ export default function App() {
     setActiveView("topics");
   }
 
-  function openDistill() {
+  function openDistill(seed?: Omit<DistillSeed, "createdAt">) {
+    if (seed) {
+      setDistillSeed({ ...seed, createdAt: new Date().toISOString() });
+    }
     setActiveView("distill");
   }
 
@@ -854,10 +859,12 @@ export default function App() {
 
           {activeView === "distill" && (
             <DistillPage
+              distillSeed={distillSeed}
               savedDistills={savedDistills}
               thoughts={thoughts}
               topics={topics}
               onDeleteDistill={deleteDistill}
+              onDistillSeedConsumed={() => setDistillSeed(null)}
               onSaveDistill={saveDistill}
               onUpdateDistill={updateDistill}
             />

--- a/src/pages/DistillPage.tsx
+++ b/src/pages/DistillPage.tsx
@@ -14,6 +14,7 @@ import { SourceComposition } from "../components/SourceComposition";
 import { formatMonthDay } from "../lib/date";
 import { generateCloudDistill } from "../services/distillRepository";
 import type {
+  DistillSeed,
   DistillOutputType,
   SavedDistill,
   Thought,
@@ -22,10 +23,12 @@ import type {
 } from "../types";
 
 interface DistillPageProps {
+  distillSeed?: DistillSeed | null;
   savedDistills: SavedDistill[];
   thoughts: Thought[];
   topics: Topic[];
   onDeleteDistill: (draftId: string) => void;
+  onDistillSeedConsumed?: () => void;
   onSaveDistill: (draft: SavedDistill) => void;
   onUpdateDistill: (draft: SavedDistill) => void;
 }
@@ -103,13 +106,18 @@ function buildDistillContent(
 }
 
 export function DistillPage({
+  distillSeed,
   savedDistills,
   thoughts,
   topics,
   onDeleteDistill,
+  onDistillSeedConsumed,
   onSaveDistill,
   onUpdateDistill,
 }: DistillPageProps) {
+  void distillSeed;
+  void onDistillSeedConsumed;
+
   const [selectedTopicId, setSelectedTopicId] = useState(topics[0]?.id ?? "");
   const [outputType, setOutputType] = useState<DistillOutputType>("文章提纲");
   const [activeDraftId, setActiveDraftId] = useState<string | null>(null);

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,12 @@ export interface ContinueQuestion {
 
 export type DistillOutputType = "文章提纲" | "复盘框架" | "观点卡片";
 
+export interface DistillSeed {
+  topicId?: string;
+  sourceThoughtIds: string[];
+  createdAt: string;
+}
+
 export interface SavedDistill {
   id: string;
   topicId: string;


### PR DESCRIPTION
## Summary
- add a DistillSeed type for carrying topic and source thought ids into Distill
- store optional distillSeed state in App and pass it through to DistillPage
- keep DistillPage UI and generation behavior unchanged for now

## Validation
- npm run lint
- npm run build