### PR TITLE
[codex] Seed Distill from thought detail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -834,8 +834,11 @@ export default function App() {
               onAttachThoughtToTopic={attachThoughtToTopic}
               onContinueFromThought={continueFromThought}
               onGenerateFromThought={(thought) => {
-                setSelectedTopicId(thought.topicIds[0] ?? topics[0]?.id ?? "");
-                setActiveView("distill");
+                const topicId = thought.topicIds[0];
+                openDistill({
+                  ...(topicId ? { topicId } : {}),
+                  sourceThoughtIds: [thought.id],
+                });
               }}
               onOpenThought={openThought}
               onOpenTopic={openTopic}

--- a/src/pages/ThoughtDetailPage.tsx
+++ b/src/pages/ThoughtDetailPage.tsx
@@ -301,7 +301,7 @@ export function ThoughtDetailPage({
               onClick={() => onGenerateFromThought(thought)}
             >
               <BookOpenText size={15} strokeWidth={1.8} />
-              生成草稿
+              带这条想法生成草稿
             </button>
             <button
               className="theme-button-secondary inline-flex items-center gap-2 rounded-xl px-3.5 py-2.5 text-sm transition"


### PR DESCRIPTION
## Summary
- pass the current thought as a Distill seed when using the Thought Detail draft action
- include the first attached topic id when available
- clarify the button label without changing generation behavior

## Note
- PR #34 is still open; once it is merged, DistillPage will consume this seed and preselect the source record.

## Validation
- npm run lint
- npm run build