### PR TITLE
[codex] Add draft action to memory matches

### DIFF
--- a/src/components/MemoryMatchCard.tsx
+++ b/src/components/MemoryMatchCard.tsx
@@ -8,6 +8,7 @@ import type {
 
 interface MemoryMatchCardProps {
   match: MemoryMatch;
+  onGenerateDraft?: (thoughtId: string) => void;
   onOpenThought?: (thoughtId: string) => void;
   onFeedback?: (thoughtId: string, feedback: MemoryFeedbackType) => void;
   selectedFeedback?: MemoryFeedbackType | null;
@@ -32,6 +33,7 @@ const feedbackOptions: Array<{
 
 export function MemoryMatchCard({
   match,
+  onGenerateDraft,
   onOpenThought,
   onFeedback,
   selectedFeedback = null,
@@ -64,7 +66,7 @@ export function MemoryMatchCard({
         {match.reason}
       </div>
 
-      {(onOpenThought || showFeedback) && (
+      {(onOpenThought || onGenerateDraft || showFeedback) && (
         <div className="mt-3 flex flex-wrap gap-1.5">
           {onOpenThought && (
             <button
@@ -74,6 +76,15 @@ export function MemoryMatchCard({
             >
               打开
               <ArrowRight size={13} strokeWidth={1.8} />
+            </button>
+          )}
+          {onGenerateDraft && (
+            <button
+              className="theme-button-muted rounded-xl px-3 py-2 text-xs transition"
+              type="button"
+              onClick={() => onGenerateDraft(match.thought.id)}
+            >
+              生成草稿
             </button>
           )}
           {showFeedback &&

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -28,6 +28,7 @@ import {
 import { useMemoryFeedback } from "../hooks/useMemoryFeedback";
 import type {
   MemoryMatch,
+  DistillSeed,
   SavedDistill,
   Thought,
   ThoughtStatus,
@@ -39,7 +40,7 @@ interface SearchPageProps {
   thoughts: Thought[];
   topics: Topic[];
   onContinueFromThought: (thought: Thought) => void;
-  onNavigateDistill: () => void;
+  onNavigateDistill: (seed?: Omit<DistillSeed, "createdAt">) => void;
   onOpenThought: (thoughtId: string) => void;
   onOpenTopic: (topicId: string) => void;
 }
@@ -461,6 +462,17 @@ export function SearchPage({
                             void persistFeedback(thoughtId, {
                               feedbackType: nextFeedback,
                               context: query,
+                            });
+                          }}
+                          onGenerateDraft={(thoughtId) => {
+                            const sourceThought = thoughts.find(
+                              (thought) => thought.id === thoughtId,
+                            );
+                            if (!sourceThought) return;
+                            const topicId = sourceThought.topicIds[0];
+                            onNavigateDistill({
+                              ...(topicId ? { topicId } : {}),
+                              sourceThoughtIds: [sourceThought.id],
                             });
                           }}
                           onOpenThought={onOpenThought}

--- a/src/pages/ThoughtDetailPage.tsx
+++ b/src/pages/ThoughtDetailPage.tsx
@@ -172,6 +172,14 @@ export function ThoughtDetailPage({
                       context: thought.content,
                     });
                   }}
+                  onGenerateDraft={(thoughtId) => {
+                    const sourceThought = thoughts.find(
+                      (item) => item.id === thoughtId,
+                    );
+                    if (sourceThought) {
+                      onGenerateFromThought(sourceThought);
+                    }
+                  }}
                   onOpenThought={onOpenThought}
                 />
               ))}

--- a/src/pages/TodayPage.tsx
+++ b/src/pages/TodayPage.tsx
@@ -152,6 +152,16 @@ export function TodayPage({
                       context: draft.trim() || thoughts[0]?.content || "today",
                     });
                   }}
+                  onGenerateDraft={onGenerateDraftFromThought
+                    ? (thoughtId) => {
+                        const sourceThought = thoughts.find(
+                          (thought) => thought.id === thoughtId,
+                        );
+                        if (sourceThought) {
+                          onGenerateDraftFromThought(sourceThought);
+                        }
+                      }
+                    : undefined}
                   onOpenThought={onOpenThought}
                 />
               ))}


### PR DESCRIPTION
## Summary
- add an optional draft generation action to MemoryMatchCard
- wire related memory cards in Today, Search, and Thought Detail to send a Distill seed
- keep existing open and feedback behavior unchanged

## Validation
- npm run lint
- npm run build